### PR TITLE
Fix a bug on chimera-robobs to select objects ra=0

### DIFF
--- a/scripts/chimera-robobs
+++ b/scripts/chimera-robobs
@@ -1000,7 +1000,7 @@ class RobObs(ChimeraCLI):
                                                                       ObsBlock.completed == False,
                                                                       or_(and_(Targets.targetRa > lststart,
                                                                                Targets.targetRa < 24.),
-                                                                          and_(Targets.targetRa > 0.,
+                                                                          and_(Targets.targetRa >= 0.,
                                                                                Targets.targetRa < lstend))).join(
                 Targets).order_by(desc(Targets.targetAH))
 


### PR DESCRIPTION
When the ra is exactly equal to 0, the objects weren't chosen from the database.